### PR TITLE
Fix/includes and warnings

### DIFF
--- a/lib/nwaasiaoclient.cpp
+++ b/lib/nwaasiaoclient.cpp
@@ -1,3 +1,4 @@
+#include <functional>
 #include <sstream>
 #include <iostream>
 #include <regex>

--- a/lib/nwaasiaoclient.cpp
+++ b/lib/nwaasiaoclient.cpp
@@ -7,7 +7,7 @@
 namespace nwaasio {
 
 client::client(asio::io_service& io_service, std::string hostname, uint32_t port) 
-	: _socket(io_service), _port(port), _hostname(hostname), _io_service(io_service)
+	: _hostname(hostname), _port(port), _io_service(io_service), _socket(io_service)
 {
 	_current_reply.type = reply::reply_type::INVALID;
 }

--- a/lib/nwaasio.cpp
+++ b/lib/nwaasio.cpp
@@ -1,6 +1,7 @@
 #include <sstream>
 #include <iomanip>
 #include <cstdint>
+#include <cassert>
 #include "nwaasio.h"
 
 std::string nwaasio::error_type_string(error_type err)
@@ -18,6 +19,12 @@ std::string nwaasio::error_type_string(error_type err)
 	case error_type::COMMAND_ERROR:
 		return "command_error";
 	}
+#ifdef __EXCEPTIONS
+    throw std::runtime_error("Invalid error_type");
+#else
+    assert("unknown error value" && false);
+    return "unknown";
+#endif
 }
 
 std::string nwaasio::buffer_to_hex(const uint8_t* data, size_t size, const std::string sep)

--- a/lib/nwaasio.cpp
+++ b/lib/nwaasio.cpp
@@ -1,5 +1,6 @@
 #include <sstream>
 #include <iomanip>
+#include <cstdint>
 #include "nwaasio.h"
 
 std::string nwaasio::error_type_string(error_type err)

--- a/lib/nwaasio.h
+++ b/lib/nwaasio.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 #include <list>
 #include <map>
 #include <string>

--- a/lib/nwaasio.h
+++ b/lib/nwaasio.h
@@ -9,7 +9,7 @@ namespace nwaasio {
         NOT_ALLOWED,
         INVALID_COMMAND,
         INVALID_ARGUMENT,
-        COMMAND_ERROR
+        COMMAND_ERROR,
     };
     std::string error_type_string(error_type err);
     std::string buffer_to_hex(const uint8_t* data, size_t size, const std::string sep = "");
@@ -26,7 +26,7 @@ namespace nwaasio {
             INVALID,
             AERROR,
             ASCII,
-            BINARY
+            BINARY,
         };
         std::string	command;
         reply_type	type = reply_type::INVALID;

--- a/lib/nwaasioclient.h
+++ b/lib/nwaasioclient.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <stdint.h>
 #include "nwaasio.h"
 #include <asio/ip/tcp.hpp>

--- a/lib/nwaasioclient.h
+++ b/lib/nwaasioclient.h
@@ -83,7 +83,7 @@ namespace nwaasio {
             IDLE,
             WAITING_REPLY,
             PROCESSING_REPLY,
-            SENDING_DATA
+            SENDING_DATA,
         } _state = NWAState::NOT_CONNECTED;
         std::string	_hostname;
         uint32_t	_port;


### PR DESCRIPTION
* `functional` and `cstdint` includes are required to compile those files.
* fixes warning for `error_type_string`. An exhaustive switch-case is not enough.
* fixes warning for wrong member initialization order
* adds trailing comma to enum classes, which I believe is best practice